### PR TITLE
format && clippy pre-commit hook gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # rust-go
 This is a go application that has integration with OGS. 
+
+
+## Installing GH Hooks
+
+In the folder called `precommit_installable_hooks`, there are 
+hooks that you can 'opt-in' to for QOL. 
+
+To do this:
+`cd .git/hooks && ln -s <name_of_hook> <path to hook>`
+
+E.g.
+`cd .git/hooks && ln -s ../../precommit_installable_hooks/pre-commit ./pre-commit`

--- a/precommit_installable_hooks/pre-commit
+++ b/precommit_installable_hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -eu
+
+if ! cargo fmt -- --check
+then
+    echo "There are some code style issues."
+    echo "Run cargo fmt first."
+    exit 1
+fi
+
+if ! cargo clippy --all-targets -- -D warnings
+then
+    echo "There are some clippy issues."
+    exit 1
+fi


### PR DESCRIPTION
Adds instructions on how to opt-in to running client-local precommit actions.